### PR TITLE
feat(channel): reply quotes with image thumbnails and rich text

### DIFF
--- a/backend/open_webui/models/messages.py
+++ b/backend/open_webui/models/messages.py
@@ -123,7 +123,7 @@ class MessageUserSlimResponse(MessageUserResponse):
 
 
 class MessageReplyToResponse(MessageUserResponse):
-    reply_to_message: Optional[MessageUserSlimResponse] = None
+    reply_to_message: Optional[MessageUserResponse] = None
 
 
 class MessageWithReactionsResponse(MessageUserSlimResponse):

--- a/backend/open_webui/routers/channels.py
+++ b/backend/open_webui/routers/channels.py
@@ -8,7 +8,6 @@ from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException, Request, status, BackgroundTasks
 from fastapi.responses import Response, StreamingResponse, FileResponse
 from pydantic import BaseModel
-from pydantic import field_validator
 
 from open_webui.socket.main import (
     emit_to_users,
@@ -778,16 +777,7 @@ async def delete_channel_by_id(
 
 
 class MessageUserResponse(MessageResponse):
-    data: bool | None = None
-
-    @field_validator("data", mode="before")
-    def convert_data_to_bool(cls, v):
-        # No data or not a dict → False
-        if not isinstance(v, dict):
-            return False
-
-        # True if ANY value in the dict is non-empty
-        return any(bool(val) for val in v.values())
+    pass
 
 
 @router.get("/{id}/messages", response_model=list[MessageUserResponse])

--- a/src/lib/components/channel/MessageInput.svelte
+++ b/src/lib/components/channel/MessageInput.svelte
@@ -804,13 +804,18 @@
 									{#if (replyToMessage?.data?.files ?? []).length > 0}
 										{@const firstFile = replyToMessage.data.files[0]}
 										{#if (firstFile?.content_type ?? '').startsWith('image/')}
-											<div class="mt-1">
+											<a
+												href={`${WEBUI_API_BASE_URL}/files/${firstFile.id}/content`}
+												target="_blank"
+												rel="noopener"
+												class="mt-1 block"
+											>
 												<img
 													src={`${WEBUI_API_BASE_URL}/files/${firstFile.id}/content`}
 													alt=""
 													class="size-8 rounded object-cover"
 												/>
-											</div>
+											</a>
 										{:else}
 											<div class="pl-[1px] mt-0.5 text-xs text-gray-500 dark:text-gray-400 italic">
 												{$i18n.t('Attachment')}

--- a/src/lib/components/channel/MessageInput.svelte
+++ b/src/lib/components/channel/MessageInput.svelte
@@ -781,7 +781,7 @@
 							{#if replyToMessage !== null}
 								<div class="px-3 pt-3 text-left w-full flex flex-col z-10">
 									<div class="flex items-center justify-between w-full">
-										<div class="pl-[1px] flex items-center gap-2 text-sm">
+										<div class="pl-[1px] flex items-center gap-2 text-sm font-medium text-gray-700 dark:text-gray-300">
 											<div class="translate-y-[0.5px]">
 												<span class=""
 													>{$i18n.t('Replying to {{NAME}}', {
@@ -801,6 +801,15 @@
 											</button>
 										</div>
 									</div>
+									{#if replyToMessage?.content}
+										<div class="pl-[1px] mt-0.5 text-xs text-gray-500 dark:text-gray-400 italic line-clamp-1">
+											{replyToMessage.content}
+										</div>
+									{:else if (replyToMessage?.data?.files ?? []).length > 0}
+										<div class="pl-[1px] mt-0.5 text-xs text-gray-500 dark:text-gray-400 italic">
+											{$i18n.t('Image')}
+										</div>
+									{/if}
 								</div>
 							{/if}
 

--- a/src/lib/components/channel/MessageInput.svelte
+++ b/src/lib/components/channel/MessageInput.svelte
@@ -806,9 +806,20 @@
 											{replyToMessage.content}
 										</div>
 									{:else if (replyToMessage?.data?.files ?? []).length > 0}
-										<div class="pl-[1px] mt-0.5 text-xs text-gray-500 dark:text-gray-400 italic">
-											{$i18n.t('Image')}
-										</div>
+										{@const firstFile = replyToMessage.data.files[0]}
+										{#if (firstFile?.content_type ?? '').startsWith('image/')}
+											<div class="mt-1">
+												<img
+													src={`${WEBUI_API_BASE_URL}/files/${firstFile.id}/content`}
+													alt=""
+													class="size-8 rounded object-cover"
+												/>
+											</div>
+										{:else}
+											<div class="pl-[1px] mt-0.5 text-xs text-gray-500 dark:text-gray-400 italic">
+												{$i18n.t('Attachment')}
+											</div>
+										{/if}
 									{/if}
 								</div>
 							{/if}

--- a/src/lib/components/channel/MessageInput.svelte
+++ b/src/lib/components/channel/MessageInput.svelte
@@ -804,18 +804,14 @@
 									{#if (replyToMessage?.data?.files ?? []).length > 0}
 										{@const firstFile = replyToMessage.data.files[0]}
 										{#if (firstFile?.content_type ?? '').startsWith('image/')}
-											<a
-												href={`${WEBUI_API_BASE_URL}/files/${firstFile.id}/content`}
-												target="_blank"
-												rel="noopener"
-												class="mt-1 block"
-											>
-												<img
+											<div class="mt-1">
+												<Image
 													src={`${WEBUI_API_BASE_URL}/files/${firstFile.id}/content`}
 													alt=""
-													class="size-8 rounded object-cover"
+													imageClassName="size-8 rounded object-cover"
+													className="!outline-none"
 												/>
-											</a>
+											</div>
 										{:else}
 											<div class="pl-[1px] mt-0.5 text-xs text-gray-500 dark:text-gray-400 italic">
 												{$i18n.t('Attachment')}

--- a/src/lib/components/channel/MessageInput.svelte
+++ b/src/lib/components/channel/MessageInput.svelte
@@ -801,11 +801,7 @@
 											</button>
 										</div>
 									</div>
-									{#if replyToMessage?.content}
-										<div class="pl-[1px] mt-0.5 text-xs text-gray-500 dark:text-gray-400 italic line-clamp-1">
-											{replyToMessage.content}
-										</div>
-									{:else if (replyToMessage?.data?.files ?? []).length > 0}
+									{#if (replyToMessage?.data?.files ?? []).length > 0}
 										{@const firstFile = replyToMessage.data.files[0]}
 										{#if (firstFile?.content_type ?? '').startsWith('image/')}
 											<div class="mt-1">
@@ -820,6 +816,11 @@
 												{$i18n.t('Attachment')}
 											</div>
 										{/if}
+									{/if}
+									{#if replyToMessage?.content}
+										<div class="pl-[1px] mt-0.5 text-xs text-gray-500 dark:text-gray-400 italic line-clamp-1">
+											{replyToMessage.content}
+										</div>
 									{/if}
 								</div>
 							{/if}

--- a/src/lib/components/channel/MessageInput.svelte
+++ b/src/lib/components/channel/MessageInput.svelte
@@ -803,11 +803,11 @@
 									</div>
 									{#if (replyToMessage?.data?.files ?? []).length > 0}
 										{@const firstFile = replyToMessage.data.files[0]}
-										{#if (firstFile?.content_type ?? '').startsWith('image/')}
+										{#if firstFile?.id && (firstFile?.content_type ?? '').startsWith('image/')}
 											<div class="mt-1">
 												<Image
 													src={`${WEBUI_API_BASE_URL}/files/${firstFile.id}/content`}
-													alt=""
+													alt={$i18n.t('Quoted image')}
 													imageClassName="size-8 rounded object-cover"
 													className="!outline-none"
 												/>

--- a/src/lib/components/channel/Messages/Message.svelte
+++ b/src/lib/components/channel/Messages/Message.svelte
@@ -259,7 +259,7 @@
 							$i18n.t('Unknown User')}
 					</div>
 
-					<div class="flex items-center gap-1.5 italic text-sm text-gray-500 dark:text-gray-400 w-full flex-1 min-w-0">
+					<div class="flex items-center gap-1.5 w-full flex-1 min-w-0">
 						{#if (message?.reply_to_message?.data?.files ?? []).length > 0}
 							{@const firstFile = message.reply_to_message.data.files[0]}
 							{#if (firstFile?.content_type ?? '').startsWith('image/')}
@@ -276,18 +276,18 @@
 									/>
 								</a>
 							{:else}
-								<span class="shrink-0">{$i18n.t('Attachment')}</span>
+								<span class="shrink-0 text-xs text-gray-500 dark:text-gray-400 italic">{$i18n.t('Attachment')}</span>
 							{/if}
 						{/if}
 						{#if message?.reply_to_message?.content}
-							<span class="truncate">
+							<div class="markdown-prose prose-sm max-w-none flex-1 min-w-0 line-clamp-1">
 								<Markdown
 									id={`${message.id}-reply-to`}
 									content={message.reply_to_message.content}
 									paragraphTag="span"
 									editCodeBlock={false}
 								/>
-							</span>
+							</div>
 						{/if}
 					</div>
 				</button>

--- a/src/lib/components/channel/Messages/Message.svelte
+++ b/src/lib/components/channel/Messages/Message.svelte
@@ -263,18 +263,16 @@
 						{#if (message?.reply_to_message?.data?.files ?? []).length > 0}
 							{@const firstFile = message.reply_to_message.data.files[0]}
 							{#if (firstFile?.content_type ?? '').startsWith('image/')}
-								<a
-									href={`${WEBUI_API_BASE_URL}/files/${firstFile.id}/content`}
-									target="_blank"
-									rel="noopener"
-									on:click|stopPropagation
-								>
-									<img
+								<!-- svelte-ignore a11y-click-events-have-key-events -->
+								<!-- svelte-ignore a11y-no-static-element-interactions -->
+								<div on:click|stopPropagation class="shrink-0">
+									<Image
 										src={`${WEBUI_API_BASE_URL}/files/${firstFile.id}/content`}
 										alt=""
-										class="size-4 shrink-0 rounded object-cover"
+										imageClassName="size-4 rounded object-cover"
+										className="!outline-none"
 									/>
-								</a>
+								</div>
 							{:else}
 								<span class="shrink-0 text-xs text-gray-500 dark:text-gray-400 italic">{$i18n.t('Attachment')}</span>
 							{/if}

--- a/src/lib/components/channel/Messages/Message.svelte
+++ b/src/lib/components/channel/Messages/Message.svelte
@@ -266,12 +266,13 @@
 							<img
 								src={`${WEBUI_API_BASE_URL}/files/${firstFile.id}/content`}
 								alt=""
-								class="size-4 inline rounded object-cover"
+								class="size-4 inline rounded object-cover mr-1"
 							/>
 						{:else}
-							{$i18n.t('Attachment')}
+							<span class="mr-1">{$i18n.t('Attachment')}</span>
 						{/if}
-					{:else}
+					{/if}
+					{#if message?.reply_to_message?.content}
 						<Markdown id={`${message.id}-reply-to`} content={message?.reply_to_message?.content} />
 					{/if}
 					</div>

--- a/src/lib/components/channel/Messages/Message.svelte
+++ b/src/lib/components/channel/Messages/Message.svelte
@@ -260,7 +260,20 @@
 					</div>
 
 					<div class="italic text-sm text-gray-500 dark:text-gray-400 line-clamp-1 w-full flex-1">
+						{#if (message?.reply_to_message?.data?.files ?? []).length > 0}
+						{@const firstFile = message.reply_to_message.data.files[0]}
+						{#if (firstFile?.content_type ?? '').startsWith('image/')}
+							<img
+								src={`${WEBUI_API_BASE_URL}/files/${firstFile.id}/content`}
+								alt=""
+								class="size-4 inline rounded object-cover"
+							/>
+						{:else}
+							{$i18n.t('Attachment')}
+						{/if}
+					{:else}
 						<Markdown id={`${message.id}-reply-to`} content={message?.reply_to_message?.content} />
+					{/if}
 					</div>
 				</button>
 			</div>

--- a/src/lib/components/channel/Messages/Message.svelte
+++ b/src/lib/components/channel/Messages/Message.svelte
@@ -280,7 +280,14 @@
 							{/if}
 						{/if}
 						{#if message?.reply_to_message?.content}
-							<span class="truncate">{message.reply_to_message.content}</span>
+							<span class="truncate">
+								<Markdown
+									id={`${message.id}-reply-to`}
+									content={message.reply_to_message.content}
+									paragraphTag="span"
+									editCodeBlock={false}
+								/>
+							</span>
 						{/if}
 					</div>
 				</button>

--- a/src/lib/components/channel/Messages/Message.svelte
+++ b/src/lib/components/channel/Messages/Message.svelte
@@ -262,13 +262,13 @@
 					<div class="flex items-center gap-1.5 w-full flex-1 min-w-0">
 						{#if (message?.reply_to_message?.data?.files ?? []).length > 0}
 							{@const firstFile = message.reply_to_message.data.files[0]}
-							{#if (firstFile?.content_type ?? '').startsWith('image/')}
+							{#if firstFile?.id && (firstFile?.content_type ?? '').startsWith('image/')}
 								<!-- svelte-ignore a11y-click-events-have-key-events -->
 								<!-- svelte-ignore a11y-no-static-element-interactions -->
 								<div on:click|stopPropagation class="shrink-0">
 									<Image
 										src={`${WEBUI_API_BASE_URL}/files/${firstFile.id}/content`}
-										alt=""
+										alt={$i18n.t('Quoted image')}
 										imageClassName="size-4 rounded object-cover"
 										className="!outline-none"
 									/>

--- a/src/lib/components/channel/Messages/Message.svelte
+++ b/src/lib/components/channel/Messages/Message.svelte
@@ -259,22 +259,29 @@
 							$i18n.t('Unknown User')}
 					</div>
 
-					<div class="italic text-sm text-gray-500 dark:text-gray-400 line-clamp-1 w-full flex-1">
+					<div class="flex items-center gap-1.5 italic text-sm text-gray-500 dark:text-gray-400 w-full flex-1 min-w-0">
 						{#if (message?.reply_to_message?.data?.files ?? []).length > 0}
-						{@const firstFile = message.reply_to_message.data.files[0]}
-						{#if (firstFile?.content_type ?? '').startsWith('image/')}
-							<img
-								src={`${WEBUI_API_BASE_URL}/files/${firstFile.id}/content`}
-								alt=""
-								class="size-4 inline rounded object-cover mr-1"
-							/>
-						{:else}
-							<span class="mr-1">{$i18n.t('Attachment')}</span>
+							{@const firstFile = message.reply_to_message.data.files[0]}
+							{#if (firstFile?.content_type ?? '').startsWith('image/')}
+								<a
+									href={`${WEBUI_API_BASE_URL}/files/${firstFile.id}/content`}
+									target="_blank"
+									rel="noopener"
+									on:click|stopPropagation
+								>
+									<img
+										src={`${WEBUI_API_BASE_URL}/files/${firstFile.id}/content`}
+										alt=""
+										class="size-4 shrink-0 rounded object-cover"
+									/>
+								</a>
+							{:else}
+								<span class="shrink-0">{$i18n.t('Attachment')}</span>
+							{/if}
 						{/if}
-					{/if}
-					{#if message?.reply_to_message?.content}
-						{message.reply_to_message.content}
-					{/if}
+						{#if message?.reply_to_message?.content}
+							<span class="truncate">{message.reply_to_message.content}</span>
+						{/if}
 					</div>
 				</button>
 			</div>

--- a/src/lib/components/channel/Messages/Message.svelte
+++ b/src/lib/components/channel/Messages/Message.svelte
@@ -273,7 +273,7 @@
 						{/if}
 					{/if}
 					{#if message?.reply_to_message?.content}
-						<Markdown id={`${message.id}-reply-to`} content={message?.reply_to_message?.content} />
+						{message.reply_to_message.content}
 					{/if}
 					</div>
 				</button>


### PR DESCRIPTION
## Summary
- Show quoted message content below the "Replying to" header in both the compose area and rendered messages
- Display image thumbnails inline in reply quotes (opens lightbox on click, no redirect)
- Render quoted text with full rich text / Markdown styling using `prose` classes

## Test plan
- [ ] Reply to a text message — quoted content shows in compose area and in the rendered reply
- [ ] Reply to a message with an image — thumbnail appears in compose area and message quote
- [ ] Click thumbnail in rendered message quote — lightbox opens (same as clicking original image)
- [ ] Quoted text with bold/code/links renders correctly (not plain text)
- [ ] Long quoted text truncates to one line with ellipsis

## Related
- Pairs with swipe-to-dismiss PR (pending)

---
Generated with [Claude Code](https://claude.com/claude-code)

## Review Fixes
- Added `firstFile?.id &&` guard before building thumbnail URL in both `Message.svelte` and `MessageInput.svelte` to prevent `/files/undefined/content` requests
- Replaced `alt=""` with `alt={$i18n.t('Quoted image')}` for meaningful screen reader context